### PR TITLE
Change "observed failure at" text to be clickable in addition to the (very small) checkbox.

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -188,7 +188,9 @@ showFailures = do
                 forM_ events $ \event -> H.tr $ do
                   H.td $ H.input ! A.type_ "checkbox" ! A.name "event_id"
                                  ! A.value (Blaze.toValue $ failedEventId event)
-                  H.td $ Blaze.toHtml (show $ observedFailureAt event)
+                                 ! A.id ("checkbox-" ++ Blaze.toValue $ failedEventId event)
+                  H.td $ H.label ! A.for ("checkbox-" ++ Blaze.toValue $ failedEventId event)
+                                 $ Blaze.toHtml (show $ observedFailureAt event)
                   H.td $ Blaze.toHtml (failedEventType event)
                   H.td $ if Sequence.null (failureReasons event)
                     then "Nothing logged"


### PR DESCRIPTION
Hopefully got this right. Hoping to get &lt;label for="checkbox-666"&gt;{text from before}&lt;/label&gt; in the second column, and &lt;input id="checkbox-666" ...&gt; in the first.
